### PR TITLE
Changes in current limiting and fmax enforcement

### DIFF
--- a/include/project/param_prj.h
+++ b/include/project/param_prj.h
@@ -125,7 +125,7 @@ extern const char* errorListString;
     PARAM_ENTRY(CAT_MOTOR,   respolepairs,"",        1,      16,     1,      93  ) \
     PARAM_ENTRY(CAT_MOTOR,   encmode,     ENCMODES,  0,      5,      0,      75  ) \
     PARAM_ENTRY(CAT_MOTOR,   fmin,        "Hz",      0,      400,    1,      34  ) \
-    PARAM_ENTRY(CAT_MOTOR,   fmax,        "Hz",      0,      1000,   200,    9   ) \
+    PARAM_ENTRY(CAT_MOTOR,   fmax,        "Hz",      21,     1000,   200,    9   ) \
     PARAM_ENTRY(CAT_MOTOR,   numimp,      "ppr",     8,      8192,   60,     15  ) \
     PARAM_ENTRY(CAT_MOTOR,   dirchrpm,    "rpm",     0,      2000,   100,    87  ) \
     PARAM_ENTRY(CAT_MOTOR,   dirmode,     DIRMODES,  0,      3,      1,      95  ) \

--- a/src/generic/fu.cpp
+++ b/src/generic/fu.cpp
@@ -41,7 +41,7 @@ uint32_t MotorVoltage::GetAmpPerc(u32fp frq, u32fp perc)
    {
       amp = maxAmp;
    }
-   if (frq > (maxFrq - FRQ_DRT_STR))
+   if ((s32fp)frq > (s32fp)(maxFrq - FRQ_DRT_STR))
    {
       s32fp diff = maxFrq - frq;
       diff = diff < 0 ? 0 : diff;

--- a/src/project/pwmgeneration.cpp
+++ b/src/project/pwmgeneration.cpp
@@ -300,8 +300,6 @@ static s32fp GetIlMax(s32fp il1, s32fp il2)
    s32fp ilMax = MAX(il1, il2);
    ilMax = MAX(ilMax, il3);
 
-   Param::SetFlt(Param::ilmax, ilMax);
-
    return ilMax;
 }
 

--- a/src/project/pwmgeneration.cpp
+++ b/src/project/pwmgeneration.cpp
@@ -274,7 +274,7 @@ static s32fp LimitCurrent()
    s32fp a = imax / 20; //Start acting at 80% of imax
    s32fp imargin = imax - ilMax;
    s32fp curLimSpnt = FP_DIV(100 * imargin, a);
-   s32fp slipSpnt = FP_DIV(fslip *  imargin, a);
+   s32fp slipSpnt = FP_DIV(FP_MUL(fslip, imargin), a);
    slipSpnt = MAX(slipmin, slipSpnt);
    curLimSpnt = MAX(FP_FROMINT(40), curLimSpnt); //Never go below 40%
    int filter = Param::GetInt(curLimSpnt < curLimSpntFiltered ? Param::ifltfall : Param::ifltrise);
@@ -303,6 +303,17 @@ static s32fp GetIlMax(s32fp il1, s32fp il2)
    Param::SetFlt(Param::ilmax, ilMax);
 
    return ilMax;
+}
+
+static s32fp GetIlSVM(s32fp il1, s32fp il2) {
+	s32fp il3 = -il1 - il2;
+	s32fp ilMax = MAX(il1, il2);
+	ilMax = MAX(ilMax, il3);
+
+	s32fp ilMin = MIN(il1, il2);
+	ilMin = MIN(ilMin, il3);
+
+	return ABS((ilMin + ilMax) / 4);
 }
 
 static s32fp GetCurrent(AnaIn::AnaIns input, s32fp offset, s32fp gain)
@@ -362,10 +373,14 @@ static s32fp ProcessCurrents()
       Param::SetFlt(Param::il2rms, rms);
    }
 
+   s32fp ilMax = GetIlMax(il1, il2);
+   s32fp ilSvm = GetIlSVM(il1, il2);
+   
    Param::SetFlt(Param::il1, il1);
    Param::SetFlt(Param::il2, il2);
 
-   return GetIlMax(il1, il2);
+   Param::SetFlt(Param::ilmax, (ilMax - ilSvm));
+   return (ilMax - ilSvm);
 }
 
 static void CalcNextAngleSync(int dir)


### PR DESCRIPTION
+ Fixed `fmax` enforcement issue in `fu` module when `fmax` is set <20. Also, minimum `fmax` is now limited to 21 Hz in `param_prj.h`.
+ Corrected a fixed-point multiplication issue in the `LimitCurrent` method
+ `ilmax` is updated in `ProcessCurrents()` instead of `LimitCurrent()`, also it's being calculated using SVM approach