### PR TITLE
add a parameter 'encmid' - this is the midpoint reading of a sin/cos …

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -24,13 +24,14 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 130
+//Next param id (increase when adding new parameter!): 131
 //Next value Id: 2048
 /*              category     name         unit       min     max     default id */
 
 #define MOTOR_PARAMETERS_COMMON \
     PARAM_ENTRY(CAT_MOTOR,   polepairs,   "",        1,      16,     2,      32  ) \
     PARAM_ENTRY(CAT_MOTOR,   respolepairs,"",        1,      16,     1,      93  ) \
+    PARAM_ENTRY(CAT_MOTOR,   encmid,      "",        1,      4096,   2048,   130 ) \
     PARAM_ENTRY(CAT_MOTOR,   encmode,     ENCMODES,  0,      5,      0,      75  ) \
     PARAM_ENTRY(CAT_MOTOR,   fmax,        "Hz",      21,     1000,   200,    9   ) \
     PARAM_ENTRY(CAT_MOTOR,   numimp,      "ppr",     8,      8192,   60,     15  ) \

--- a/src/inc_encoder.cpp
+++ b/src/inc_encoder.cpp
@@ -470,9 +470,11 @@ void Encoder::InitResolverMode()
    }
    else //SINCOS
    {
-      //Offset assumed 3.3V/2
-      adc_set_injected_offset(ADC1, 2, 2048);
-      adc_set_injected_offset(ADC1, 3, 2048);
+      //Offset assumed 3.3V/2 - 2048
+      //on my hardware, min is 0.465V, max is 2.510v, so offset is 1.4875v, or 1846
+      //this should be a parameter?
+      adc_set_injected_offset(ADC1, 2, Param::GetInt(Param::encmid));
+      adc_set_injected_offset(ADC1, 3, Param::GetInt(Param::encmid));
    }
 
    seenNorthSignal = true;


### PR DESCRIPTION
I've seen a few reports of difficulty getting a sin/cos encoder working nicely due to the 1.65V 'zero point' requirement, and also experience problems myself with this - the MLX91204 requires 5V rather than 3.3V VCC, so it's output was 2.5V +/- ~2.2V. A simple resistor divider got this to within 0.0 - 3.3V, but getting the midpoint to 1.65V exactly would require a number of tight tolerance resistors, or perhaps a trim-pot (but then these can move with vibration).

I added another parameter - encmid - which allows setting the 'zero point' to match the hardware. In my case, with the MLX91204 on a 5V supply, and using a 1.1k/2.2k resistor divider, the minimum voltage on the EncA and EncB pins was 0.465V, maximum 2.510V, giving a midpoint of 1.4875V. 1.4875/3.3 * 4096 gives 1846 for encmid.

This could potentially be set automatically by the inverter during setup by spinning the motor by hand while the inverter records the min and max readings on the pins - this would give the midpoint and amplitude of the signal, which could be saved as parameters. This doesn't tie in with the existing manual setup though, and I don't think it's unreasonable to ask a user to measure some voltages and do a quick calculation during setup!