### PR TITLE
Fix FOC current offset calibration

### DIFF
--- a/src/pwmgeneration-foc.cpp
+++ b/src/pwmgeneration-foc.cpp
@@ -285,6 +285,7 @@ void PwmGeneration::RunOffsetCalibration()
    {
       il1Avg += AnaIn::il1.Get();
       il2Avg += AnaIn::il2.Get();
+      samples++;
    }
    else
    {
@@ -292,6 +293,4 @@ void PwmGeneration::RunOffsetCalibration()
       il1Avg = il2Avg = 0;
       samples = 0;
    }
-
-   samples++;
 }


### PR DESCRIPTION
This fixes an off-by-one error in the FOC current offset
calibration routine. The initial calibration sequence
computes correctly. After the offset has been computed and
the counters reset subsequent calibration sequences will
miss one sample because the sample count in incremented
indpendently from where the samples are averaged.

Tests:
 - Force AnaIn::il1.Get() and AnaIn::il2.Get() to return 2048
 - Verify that SetCurrentOffset() is always called with 2048
   for offset1 and offset2. Previously this would be 2044.