### PR TITLE
Don't apply backwards regen if motor is already turning backwards

### DIFF
--- a/src/pwmgeneration-sine.cpp
+++ b/src/pwmgeneration-sine.cpp
@@ -121,6 +121,12 @@ void PwmGeneration::SetTorquePercent(float torque)
          fslipspnt = fslipmin + roundingError;
       }
    }
+   else if (Encoder::GetRotorDirection() != Param::GetInt(Param::dir))
+   {
+      // Do not apply negative torque if we are already traveling backwards.
+      fslipspnt = 0;
+      ampnomLocal = 0;
+   }
    else
    {
       ampnomLocal = -torque;


### PR DESCRIPTION
This patch prevents a negative torque request from doing anything if the motor is already spinning backwards. It is essentially just a safety feature to prevent regen runaway.