### PR TITLE
make PwmGeneration::slipIncr signed

### DIFF
--- a/include/pwmgeneration.h
+++ b/include/pwmgeneration.h
@@ -65,7 +65,7 @@ class PwmGeneration
       static uint16_t pwmfrq;
       static uint16_t angle;
       static s32fp ampnom;
-      static uint16_t slipIncr;
+      static int16_t slipIncr;
       static s32fp fslip;
       static s32fp frq;
       static s32fp frqFiltered;

--- a/src/pwmgeneration.cpp
+++ b/src/pwmgeneration.cpp
@@ -46,7 +46,7 @@ uint8_t  PwmGeneration::shiftForTimer;
 int      PwmGeneration::opmode;
 s32fp    PwmGeneration::ilofs[2];
 int      PwmGeneration::polePairRatio;
-uint16_t PwmGeneration::slipIncr;
+int16_t  PwmGeneration::slipIncr;
 
 static int      execTicks;
 static bool     tripped;


### PR DESCRIPTION
This patch actually makes no functional difference, but holding negative values in an unsigned int made me uncomfortable.