### PR TITLE
Make sine output filter "filterConst" a configurable value "sinefilter"

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -24,7 +24,7 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 146
+//Next param id (increase when adding new parameter!): 148
 //Next value Id: 2049
 /*              category     name         unit       min     max     default id */
 
@@ -47,6 +47,7 @@
     PARAM_ENTRY(CAT_MOTOR,   udcnom,      "V",       0,      1000,   0,      78  ) \
     PARAM_ENTRY(CAT_MOTOR,   fslipmin,    "Hz",      0.3,    10,     1,      37  ) \
     PARAM_ENTRY(CAT_MOTOR,   fslipmax,    "Hz",      0.3,    10,     3,      33  ) \
+    PARAM_ENTRY(CAT_MOTOR,   sinefilter,  "dig",     0,      10,     4,      147 ) \
     PARAM_ENTRY(CAT_MOTOR,   fslipconstmax,"Hz",     0,      10,     5,      100 )
 
 #define MOTOR_PARAMETERS_FOC \

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -47,7 +47,6 @@
     PARAM_ENTRY(CAT_MOTOR,   udcnom,      "V",       0,      1000,   0,      78  ) \
     PARAM_ENTRY(CAT_MOTOR,   fslipmin,    "Hz",      0.3,    10,     1,      37  ) \
     PARAM_ENTRY(CAT_MOTOR,   fslipmax,    "Hz",      0.3,    10,     3,      33  ) \
-    PARAM_ENTRY(CAT_MOTOR,   sinefilter,  "dig",     0,      10,     4,      147 ) \
     PARAM_ENTRY(CAT_MOTOR,   fslipconstmax,"Hz",     0,      10,     5,      100 )
 
 #define MOTOR_PARAMETERS_FOC \
@@ -116,6 +115,7 @@
 #define THROTTLE_PARAMETERS_SINE \
     PARAM_ENTRY(CAT_THROTTLE,ampmin,      "%",       0,      100,    10,     4   ) \
     PARAM_ENTRY(CAT_THROTTLE,slipstart,   "%",       10,     100,    50,     90  ) \
+    PARAM_ENTRY(CAT_THROTTLE,throtfilter, "dig",     0,      10,     4,      147 )
 
 #define THROTTLE_PARAMETERS_FOC \
    PARAM_ENTRY(CAT_THROTTLE,throtcur,    "A/%",       0,     10,     1,     105  )

--- a/src/pwmgeneration-sine.cpp
+++ b/src/pwmgeneration-sine.cpp
@@ -83,7 +83,7 @@ void PwmGeneration::Run()
 
 void PwmGeneration::SetTorquePercent(float torque)
 {
-   int filterConst = Param::GetInt(Param::sinefilter);
+   int filterConst = Param::GetInt(Param::throtfilter);
    float roundingError = FP_TOFLOAT((float)((1 << filterConst) - 1));
    float fslipmin = Param::GetFloat(Param::fslipmin);
    float ampmin = Param::GetFloat(Param::ampmin);

--- a/src/pwmgeneration-sine.cpp
+++ b/src/pwmgeneration-sine.cpp
@@ -83,8 +83,8 @@ void PwmGeneration::Run()
 
 void PwmGeneration::SetTorquePercent(float torque)
 {
-   const int filterConst = 4;
-   const float roundingError = FP_TOFLOAT((float)((1 << filterConst) - 1));
+   int filterConst = Param::GetInt(Param::sinefilter);
+   float roundingError = FP_TOFLOAT((float)((1 << filterConst) - 1));
    float fslipmin = Param::GetFloat(Param::fslipmin);
    float ampmin = Param::GetFloat(Param::ampmin);
    float slipstart = Param::GetFloat(Param::slipstart);


### PR DESCRIPTION
I found that the hardcoded output filter on sine ampnom and slip caused an excessive delay to throttle response. This patch makes it a configurable value.