### PR TITLE
Add an option to scale voltage and slip simultaneously with throttle

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -115,6 +115,7 @@
 #define THROTTLE_PARAMETERS_SINE \
     PARAM_ENTRY(CAT_THROTTLE,ampmin,      "%",       0,      100,    10,     4   ) \
     PARAM_ENTRY(CAT_THROTTLE,slipstart,   "%",       10,     100,    50,     90  ) \
+    PARAM_ENTRY(CAT_THROTTLE,sinecurve,   SINECURVES,0,      1,      0,      146 ) \
     PARAM_ENTRY(CAT_THROTTLE,throtfilter, "dig",     0,      10,     4,      147 )
 
 #define THROTTLE_PARAMETERS_FOC \
@@ -251,6 +252,7 @@
 #define SNS_HS       "0=JCurve, 1=Semikron, 2=MBB600, 3=KTY81, 4=PT1000, 5=NTCK45_2k2, 6=Leaf, 7=BMW-i3"
 #define SNS_M        "12=KTY83-110, 13=KTY84-130, 14=Leaf, 15=KTY81-110, 16=Toyota, 21=OutlanderFront, 22=EpcosB57861-S, 23=ToyotaGen2"
 #define PWMFUNCS     "0=tmpm, 1=tmphs, 2=speed, 3=speedfrq"
+#define SINECURVES   "0=VoltageSlip, 1=Simultaneous"
 #define CRUISEMODS   "0=Button, 1=Switch, 2=CAN, 3=ThrottlePot"
 #define DIRMODES     "0=Button, 1=Switch, 2=ButtonReversed, 3=SwitchReversed, 4=DefaultForward"
 #define IDLEMODS     "0=Always, 1=NoBrake, 2=Cruise, 3=Off, 4=HillHold"

--- a/src/pwmgeneration-sine.cpp
+++ b/src/pwmgeneration-sine.cpp
@@ -85,40 +85,52 @@ void PwmGeneration::SetTorquePercent(float torque)
 {
    int filterConst = Param::GetInt(Param::throtfilter);
    float roundingError = FP_TOFLOAT((float)((1 << filterConst) - 1));
+   int sinecurve = Param::GetInt(Param::sinecurve);
    float fslipmin = Param::GetFloat(Param::fslipmin);
    float ampmin = Param::GetFloat(Param::ampmin);
    float slipstart = Param::GetFloat(Param::slipstart);
+   float fstat = Param::GetFloat(Param::fstat);
+   float fweak = Param::GetFloat(Param::fweakcalc);
+   float fslipmax = Param::GetFloat(Param::fslipmax);
+   float fconst = Param::GetFloat(Param::fconst);
+   float fslipconstmax = Param::GetFloat(Param::fslipconstmax);
+
    float ampnomLocal;
    float fslipspnt = 0;
 
    if (torque >= 0)
    {
-      /* In async mode first X% throttle commands amplitude, X-100% raises slip */
-      ampnomLocal = ampmin + (100.0f - ampmin) * torque / slipstart;
-
-      if (torque >= slipstart)
+      if (fstat > fweak)
       {
-         float fstat = Param::GetFloat(Param::fstat);
-         float fweak = Param::GetFloat(Param::fweakcalc);
-         float fslipmax = Param::GetFloat(Param::fslipmax);
-
-         if (fstat > fweak)
-         {
-            float fconst = Param::GetFloat(Param::fconst);
-            float fslipconstmax = Param::GetFloat(Param::fslipconstmax);
-            //Basically, for every Hz above fweak we get a fraction of
-            //the difference between fslipconstmax and fslipmax
-            //of additional slip
-            fslipmax += (fstat - fweak) / (fconst - fweak) * (fslipconstmax - fslipmax);
-            fslipmax = MIN(fslipmax, fslipconstmax); //never exceed fslipconstmax!
-         }
-
-         float fslipdiff = fslipmax - fslipmin;
-         fslipspnt = roundingError + fslipmin + (fslipdiff * (torque - slipstart)) / (100.0f - slipstart);
+         // Fslipmax is increased up to fslipconstmax as frequency exceeds fweak
+         fslipmax += (fstat - fweak) / (fconst - fweak) * (fslipconstmax - fslipmax);
+         // Never exceed fslipconstmax!
+         fslipmax = MIN(fslipmax, fslipconstmax); //never exceed fslipconstmax!
       }
+
+      // If simultaneous curve selected. We will ramp voltage and slip simultaneously.
+      if (sinecurve)
+      {
+         // Amplitude is simply scaled from ampmin to 100%
+         ampnomLocal = ampmin + (100.0f - ampmin) * torque / 100.0f;
+
+         // Slip is scaled from fslipmin to fslipmax
+         fslipspnt = roundingError + fslipmin + (fslipmax - fslipmin) * torque / 100.0f;
+      }
+      // If sequential curve selected. first X% throttle commands amplitude, X-100% raises slip
       else
       {
-         fslipspnt = fslipmin + roundingError;
+         ampnomLocal = ampmin + (100.0f - ampmin) * torque / slipstart;
+
+         if (torque >= slipstart)
+         {
+            float fslipdiff = fslipmax - fslipmin;
+            fslipspnt = roundingError + fslipmin + (fslipdiff * (torque - slipstart)) / (100.0f - slipstart);
+         }
+         else
+         {
+            fslipspnt = fslipmin + roundingError;
+         }
       }
    }
    else if (Encoder::GetRotorDirection() != Param::GetInt(Param::dir))


### PR DESCRIPTION
This patch adds an option to configure an alternative throttle curve.
Specifically, in addition to the existing option of increasing voltage first and slip afterwards, this adds the option to increase voltage and slip simultaneously.
This is something people can experiment with, but I have found it allows a greater degree of control. It is particularly useful for anyone who wishes to set fslipmax=fsmipmin and still utilize the full throttle travel.