### PR TITLE
Fix #24 and suppress linker warning only when supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,24 @@ Q := @
 NULL := 2>/dev/null
 endif
 
+# try-run
+# Usage: option = $(call try-run, command,option-ok,otherwise)
+# Exit code chooses option.
+try-run = $(shell set -e;		\
+	if ($(1)) >/dev/null 2>&1;	\
+	then echo "$(2)";		\
+	else echo "$(3)";		\
+	fi)
+
+# Test a linker (ld) option and return the gcc link command equivalent
+comma := ,
+link_command := -Wl$(comma)
+ld-option = $(call try-run, $(PREFIX)-ld $(1) -v,$(link_command)$(1))
+
+# Test whether we can suppress a safe warning about rwx segments
+# only supported on binutils 2.39 or later
+LDFLAGS	+= $(call ld-option,--no-warn-rwx-segments)
+
 all: directories images
 Debug:images
 Release: images


### PR DESCRIPTION
Due to the way that gcc generates .init_array sections containing C++ global object constructors it can result in ELF object file sections that are marked Read Write and eXecute. With binutils 2.39 or newer this will result in a warning. For an embedded use case like this inverter it can safely be suppressed.

Suppressing the warning is not possible on earlier versions of binutils (GNU ld). The makefile now tests whether the link option will succeed before trying to use it.

Tests:
 - Build with gcc 12.2.0 and binutils 2.39 - verify:
   - No linker warning
   - Link command contains -Wl,--no-warn-rwx-segments
 - Build with gcc 10.3.1 and binutils 2.36.1 - verify:
    - No linker warning
   - Link command does not contain -Wl,--no-warn-rwx-segments