### PR TITLE
Improve ilMax calculation

### DIFF
--- a/src/pwmgeneration-sine.cpp
+++ b/src/pwmgeneration-sine.cpp
@@ -33,6 +33,7 @@
 #define SHIFT_90DEG  (uint16_t)16384
 #define FRQ_TO_ANGLE(frq) FP_TOINT((frq << SineCore::BITS) / pwmfrq)
 #define DIGIT_TO_DEGREE(a) FP_FROMINT(angle) / (65536 / 360)
+#define INV_SQRT_1_5 FP_FROMFLT(0.8164965809)
 
 void PwmGeneration::Run()
 {
@@ -187,14 +188,9 @@ s32fp PwmGeneration::LimitCurrent()
 s32fp PwmGeneration::GetIlMax(s32fp il1, s32fp il2)
 {
    s32fp il3 = -il1 - il2;
-   s32fp offset = SineCore::CalcSVPWMOffset(il1, il2, il3) / 2;
-   offset = ABS(offset);
-   il1 = ABS(il1);
-   il2 = ABS(il2);
-   il3 = ABS(il3);
-   s32fp ilMax = MAX(il1, il2);
-   ilMax = MAX(ilMax, il3);
-   ilMax -= offset;
+   s32fp ilMax = FP_MUL(il1, il1) + FP_MUL(il2, il2) + FP_MUL(il3, il3);
+   ilMax = fp_sqrt(ilMax);
+   ilMax = FP_MUL(ilMax, INV_SQRT_1_5);
 
    return ilMax;
 }


### PR DESCRIPTION
This is a more mathematical way to calculate an instantaneous value for the overall 3 phase AC current. It's scaled to equal the theoretical peak value all three phases. See images for theoretical results and actual results in my SDU.
![imax](https://user-images.githubusercontent.com/9741/212685489-f380d6b7-da3b-488a-9f77-8934dc3bf396.png)
![Screenshot at 2023-01-16 12-41-45](https://user-images.githubusercontent.com/9741/212685511-5354e64e-d1bd-40a4-b842-3d89a46281a2.png)
