### PR TITLE
Use GitHub Actions for continuous integration with firmware builds

### DIFF
--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -30,8 +30,13 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: SINE firmware
-          path: stm32_sine{.bin,.hex}
+          name: SINE firmware binary
+          path: stm32_sine.bin
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SINE firmware hex
+          path: stm32_sine.hex
 
       - name: Build FOC firmware
         run: |
@@ -39,9 +44,14 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: FOC firmware
-          path: stm32_foc{.bin,.hex}
+          name: FOC firmware binary
+          path: stm32_foc.bin
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: FOC firmware hex
+          path: stm32_foc.hex
+  
 # Unit tests are currently broken so don't build and run them for now
 #- name: Build unit tests on host
 #        run: |

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           make -C test
 
-      - name: Run unit tests on host
-        run: |
-          test/test_sine
+# Unit tests are currently broken so don't run them for now
+#      - name: Run unit tests on host
+#        run: |
+#          test/test_sine

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -1,0 +1,41 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: build-linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install build package dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-arm-none-eabi
+
+      - name: Build dependencies
+        run: |
+          echo "Number of processors:" `nproc`
+          make get-deps -j `nproc`
+
+      - name: Build SINE firmware
+        run: |
+          make CONTROL=SINE clean all
+
+      - name: Build FOC firmware
+        run: |
+          make CONTROL=FOC clean all
+
+      - name: Build unit tests on host
+        run: |
+          make -C test
+
+      - name: Run unit tests on host
+        run: |
+          test/test_sine

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -28,9 +28,19 @@ jobs:
         run: |
           make CONTROL=SINE clean all
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SINE firmware
+          path: stm32_sine{.bin,.hex}
+
       - name: Build FOC firmware
         run: |
           make CONTROL=FOC clean all
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: FOC firmware
+          path: stm32_foc{.bin,.hex}
 
 # Unit tests are currently broken so don't build and run them for now
 #- name: Build unit tests on host

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -32,11 +32,12 @@ jobs:
         run: |
           make CONTROL=FOC clean all
 
-      - name: Build unit tests on host
-        run: |
-          make -C test
-
-# Unit tests are currently broken so don't run them for now
+# Unit tests are currently broken so don't build and run them for now
+#- name: Build unit tests on host
+#        run: |
+#          make -C test
+#
 #      - name: Run unit tests on host
 #        run: |
 #          test/test_sine
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/jsphuebner/stm32-sine.svg?branch=master)](https://travis-ci.com/jsphuebner/stm32-sine)
+[![Build status](../../actions/workflows/CI-build.yml/badge.svg)](../../actions/workflows/CI-build.yml)
 
 # stm32-sine
 Main firmware of the Huebner inverter project


### PR DESCRIPTION
This uses GitHub Actions to build the firmware on each push of a new commit. Each firmware build artifact is published allowing them to be downloaded by interested users. These builds are retained by GitHub for 90 days by default.

The unit tests are currently broken for both building and running. When these are fixed the corresponding lines in the workflow definition can be uncommented. These used to pass successfully.

The readme has been updated to have a "badge" that references the most recent CI build on the repo and replaces the old Travis-CI system.

The workflow is configured to run on pushes and pull requests. This means they will run on contributors repos as well as immediately prior to raising a PR reducing the likelihood of breaking changes being merged unintentionally.
