### PR TITLE
Add vehicle speed brake light threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ stm32_sine
 stm32_foc
 test/test_sine
 .vscode
+.codex

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -17,15 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define VERSION 5.39
+#define VERSION 5.41
 
 /* Entries should be ordered as follows:
    1. Saveable parameters
    2. Temporary parameters
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 164
-//Next value Id: 2058
+//Next param id (increase when adding new parameter!): 166
+//Next value Id: 2060
 /*              category     name         unit       min     max     default id */
 
 #define MOTOR_PARAMETERS_COMMON \
@@ -113,8 +113,8 @@
     PARAM_ENTRY(CAT_CHARGER, chargepwmax, "%",       0,      99,     90,     79  )
 
 #define THROTTLE_PARAMETERS_COMMON \
-    PARAM_ENTRY(CAT_THROTTLE,potmin,      "dig",     0,      3500,   0,      17  ) \
-    PARAM_ENTRY(CAT_THROTTLE,potmax,      "dig",     0,      3500,   3500,   18  ) \
+    PARAM_ENTRY(CAT_THROTTLE,potmin,      "dig",     0,      4095,   0,      17  ) \
+    PARAM_ENTRY(CAT_THROTTLE,potmax,      "dig",     0,      4095,   4095,   18  ) \
     PARAM_ENTRY(CAT_THROTTLE,pot2min,     "dig",     0,      4095,   4095,   63  ) \
     PARAM_ENTRY(CAT_THROTTLE,pot2max,     "dig",     0,      4095,   4095,   64  ) \
     PARAM_ENTRY(CAT_THROTTLE,potmode,     POTMODES,  0,      6,      0,      82  ) \
@@ -139,7 +139,7 @@
     PARAM_ENTRY(CAT_REGEN,   cruiseregen, "%",       -100,   0,      -30,    124 ) \
     PARAM_ENTRY(CAT_REGEN,   regenrampstr,"Hz",      0,      400,    10,     39  ) \
     PARAM_ENTRY(CAT_REGEN,   maxregentravelhz,"Hz",  0,      1000,   0,      158 ) \
-    PARAM_ENTRY(CAT_REGEN,   brklightout, "%",       -100,   -1,     -50,    67  )
+    PARAM_ENTRY(CAT_REGEN,   brklightout, "m/s²",    -1.3,   -0.7,   -1,     67  )
 
 #define AUTOMATION_CONTACT_PWM_COMM_PARAMETERS \
     PARAM_ENTRY(CAT_AUTOM,   idlespeed,   "rpm",     -100,   10000,  -100,   54  ) \
@@ -148,6 +148,7 @@
     PARAM_ENTRY(CAT_AUTOM,   holdkp,      "",        -100,   0,     -0.25,   138 ) \
     PARAM_ENTRY(CAT_AUTOM,   speedkp,     "",        0,      100,    0.25,   53  ) \
     PARAM_ENTRY(CAT_AUTOM,   speedflt,    "",        0,      16,     5,      57  ) \
+    PARAM_ENTRY(CAT_AUTOM,   speedcal,    "rpm/(m/s)",0.001, 100000, 1,      165 ) \
     PARAM_ENTRY(CAT_AUTOM,   cruisemode,  CRUISEMODS,0,      4,      0,      62  ) \
     PARAM_ENTRY(CAT_AUTOM,   cruisethrotlim,"%",     0,      100,    50,     155 ) \
     PARAM_ENTRY(CAT_CONTACT, udcsw,       "V",       0,      1000,   330,    20  ) \
@@ -180,6 +181,8 @@
 #define VALUE_BLOCK2 \
     VALUE_ENTRY(fstat,       "Hz",    2011 ) \
     VALUE_ENTRY(speed,       "rpm",   2012 ) \
+    VALUE_ENTRY(vehiclespeed,"m/s",   2058 ) \
+    VALUE_ENTRY(vehicleaccel,"m/s²",  2059 ) \
     VALUE_ENTRY(cruisespeed, "rpm",   2041 ) \
     VALUE_ENTRY(turns,       "",      2037 ) \
     VALUE_ENTRY(amp,         "dig",   2013 ) \

--- a/include/vehiclecontrol.h
+++ b/include/vehiclecontrol.h
@@ -55,6 +55,7 @@ class VehicleControl
       static void GetTemps(float& tmphs, float &tmpm);
       static float GetUserThrottleCommand();
       static bool GetCruiseCreepCommand(float& finalSpnt, float throtSpnt);
+      static void UpdateVehicleSpeedValues();
       static void BmwAdcAcquire();
       static void CanClear();
       static bool CanReceive(uint32_t id, uint32_t data[2], uint8_t);

--- a/src/stm32_sine.cpp
+++ b/src/stm32_sine.cpp
@@ -60,6 +60,7 @@ static CanMap* canMap;
 static CanSdo* canSdo;
 static Terminal* terminal;
 static bool seenBrakePedal = false;
+static uint8_t canMapTxSlot = 0;
 
 static void Ms100Task(void)
 {
@@ -101,8 +102,6 @@ static void Ms100Task(void)
    Param::SetFloat(Param::uac, uac);
    #endif // CONTROL
 
-   if (Param::GetInt(Param::canperiod) == CAN_PERIOD_100MS)
-      canMap->SendAll();
 }
 
 static void RunCharger(float udc)
@@ -253,8 +252,20 @@ static void Ms10Task(void)
 
    Param::SetInt(Param::uptime, rtc_get_counter_val());
 
+   if (Param::GetInt(Param::canperiod) == CAN_PERIOD_100MS)
+   {
+      canMap->SendByIndex(canMapTxSlot);
+      canMapTxSlot = (canMapTxSlot + 1) % MAX_MESSAGES;
+   }
+}
+
+static void Ms1Task(void)
+{
    if (Param::GetInt(Param::canperiod) == CAN_PERIOD_10MS)
-      canMap->SendAll();
+   {
+      canMap->SendByIndex(canMapTxSlot);
+      canMapTxSlot = (canMapTxSlot + 1) % MAX_MESSAGES;
+   }
 }
 
 /** This function is called when the user changes a parameter */
@@ -456,6 +467,7 @@ extern "C" int main(void)
 
    s.AddTask(Ms100Task, 100);
    s.AddTask(Ms10Task, 10);
+   s.AddTask(Ms1Task, 1);
 
    DigIo::prec_out.Set();
 
@@ -498,4 +510,3 @@ extern "C" int main(void)
 
    return 0;
 }
-

--- a/src/vehiclecontrol.cpp
+++ b/src/vehiclecontrol.cpp
@@ -273,10 +273,23 @@ void VehicleControl::SelectDirection()
    Param::SetInt(Param::seldir, selectedDir);
 }
 
+void VehicleControl::UpdateVehicleSpeedValues()
+{
+   static float lastVehicleSpeed = 0;
+
+   float speed = Param::GetFloat(Param::speed);
+   float vehicleSpeed = speed / Param::GetFloat(Param::speedcal);
+
+   Param::SetFloat(Param::vehiclespeed, vehicleSpeed);
+   Param::SetFloat(Param::vehicleaccel, (vehicleSpeed - lastVehicleSpeed) * 100);
+   lastVehicleSpeed = vehicleSpeed;
+}
+
 float VehicleControl::ProcessThrottle()
 {
    float throtSpnt = 0, finalSpnt;
    const float fstat = Param::GetFloat(Param::fstat);
+   UpdateVehicleSpeedValues();
 
    if ((int)Encoder::GetSpeed() < Param::GetInt(Param::throtramprpm))
       Throttle::throttleRamp = Param::GetFloat(Param::throtramp);
@@ -314,18 +327,14 @@ float VehicleControl::ProcessThrottle()
 
    Param::SetFloat(Param::potnom, finalSpnt);
 
-   const float brkLightHysteresis = 2.0f; // percent of torque request
    float brkLightThreshold = Param::GetFloat(Param::brklightout);
-   float brkLightOffThreshold = brkLightThreshold + brkLightHysteresis;
+   float brkLightOffThreshold = brkLightThreshold - brkLightThreshold * 0.1f;
+   float vehicleAccel = Param::GetFloat(Param::vehicleaccel);
    bool brakeLightOn = Param::GetBool(Param::dout_brake);
 
-   // Keep turn-off threshold in regen/coast range only, never into positive torque request
-   if (brkLightOffThreshold > 0)
-      brkLightOffThreshold = 0;
-
-   if (finalSpnt < brkLightThreshold)
+   if (vehicleAccel < brkLightThreshold)
       brakeLightOn = true;
-   else if (finalSpnt > brkLightOffThreshold)
+   else if (vehicleAccel > brkLightOffThreshold)
       brakeLightOn = false;
 
    Param::SetInt(Param::dout_brake, brakeLightOn);

--- a/test/test_vcu.cpp
+++ b/test/test_vcu.cpp
@@ -153,24 +153,31 @@ static void TestCanBrakeLightHysteresis()
    Throttle::idckp = 1;
 
    Param::SetInt(Param::potmode, POTMODE_CAN);
-   Param::SetFloat(Param::brklightout, -10);
+   Param::SetFloat(Param::speedcal, 10000);
+   Param::SetFloat(Param::brklightout, -1);
+
+   Param::SetInt(Param::speed, 11000);
+   VehicleControl::ProcessThrottle();
 
    FillInCanData(data, 500, 0, CAN_IO_FWD | CAN_IO_BRAKE, 0, 100, 1);
    vcuCan->HandleRx(vcuCanId, data, 8);
    VehicleControl::GetDigInputs();
+   Param::SetInt(Param::speed, 10890);
    VehicleControl::ProcessThrottle();
    ASSERT(Param::GetBool(Param::dout_brake));
 
    FillInCanData(data, 700, 0, CAN_IO_FWD, 0, 50, 2);
    vcuCan->HandleRx(vcuCanId, data, 8);
    VehicleControl::GetDigInputs();
+   Param::SetInt(Param::speed, 10795);
    VehicleControl::ProcessThrottle();
-   // Input chosen to stay between on-threshold (-10) and off-threshold (-8) -> light must stay on
+   // Input chosen to stay between on-threshold (-1) and off-threshold (-0.9) -> light must stay on
    ASSERT(Param::GetBool(Param::dout_brake));
 
    FillInCanData(data, 3500, 0, CAN_IO_FWD, 0, 50, 3);
    vcuCan->HandleRx(vcuCanId, data, 8);
    VehicleControl::GetDigInputs();
+   Param::SetInt(Param::speed, 10715);
    VehicleControl::ProcessThrottle();
    ASSERT(!Param::GetBool(Param::dout_brake));
 }


### PR DESCRIPTION
## Summary
- Add calibrated `vehiclespeed` and `vehicleaccel` spot values derived from the existing `speed` parameter.
- Drive `dout_brake`/`brk_out` from vehicle acceleration instead of regen torque request.
- Set `brklightout` to m/s² with a configurable range from `-1.3` to `-0.7`.

## Regulation context
For regenerative braking under DE/EU brake-light behavior:
- Brake light activation is mandatory above `1.3 m/s²` deceleration.
- Brake light activation is allowed from `0.7 m/s²` deceleration.

Because deceleration is represented as a negative acceleration here, `brklightout` is constrained to `-1.3 .. -0.7 m/s²`.

## Validation
- `make -C test`
- `./test/test_sine`
- `make`
